### PR TITLE
Removes inoperable gitcdn failover

### DIFF
--- a/background.js
+++ b/background.js
@@ -46,18 +46,12 @@ const loadStrikeData = async () => {
             try {
                 strikeData = JSON.parse(await (await fetch("https://raw.githubusercontent.com/jamespizzurro/picket-line-notifier/main/data/strikes.json", {cache: 'no-cache'})).text());
             } catch (e) {
-                console.warn("Failed to fetch strike data from raw.githubusercontent.com! Falling back to using GitCDN...", e);
+                console.warn("Failed to fetch strike data from raw.githubusercontent.com! Falling back to using jsDelivr...", e);
 
                 try {
-                    strikeData = JSON.parse(await (await fetch("https://gitcdn.link/cdn/jamespizzurro/picket-line-notifier/main/data/strikes.json", {cache: 'no-cache'})).text());
+                    strikeData = JSON.parse(await (await fetch("https://cdn.jsdelivr.net/gh/jamespizzurro/picket-line-notifier@main/data/strikes.json", {cache: 'no-cache'})).text());
                 } catch (e) {
-                    console.warn("Failed to fetch strike data from GitCDN! Falling back to using jsDelivr...", e);
-
-                    try {
-                        strikeData = JSON.parse(await (await fetch("https://cdn.jsdelivr.net/gh/jamespizzurro/picket-line-notifier@main/data/strikes.json", {cache: 'no-cache'})).text());
-                    } catch (e) {
-                        console.error("Failed to fetch strike data from jsDelivr!", e);
-                    }
+                    console.error("Failed to fetch strike data from jsDelivr!", e);
                 }
             }
 


### PR DESCRIPTION
Impacts #879

It was attempting to fail over to GitCDN, but the link was inoperable there and it is causing a firefox review flag. This resolves it by just removing that failover case. It appears to have a zero percent chance of succeeding anyway, so it shouldn't impact anything.